### PR TITLE
Link to PineTime page on pine64

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@ Watch Application System in Python
 ==================================
 
 Currently in its infancy wasp-os provides nothing more than a simple
-digital clock application for PineTime together with access to the
-MicroPython REPL for interactive testing and tweaking. However it
-keeps time well and has enough power saving functions implemented
-that it can survive for well over 24 hours between charges so even
-at this early stage it is functional as a wearable timepiece.
+digital clock application for [PineTime](https://www.pine64.org/pinetime/)
+together with access to the MicroPython REPL for interactive testing and
+tweaking. However it keeps time well and has enough power saving
+functions implemented that it can survive for well over 24 hours between
+charges so even at this early stage it is functional as a wearable
+timepiece.
 
 WASP includes a robust bootloader based on the Adafruit NRF52
 Bootloader. It has been extended to make it robust for development on


### PR DESCRIPTION
I was looking at wasp-os and needed to get back to instructions for programming bootloader.  I thought handy link towards top of README.md would help me and others.