### PR TITLE
Fixed the documentation for setting the RTC time

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To set the time and restart the main application:
 
 ~~~
 ^C
-watch.rtc.set_time((hh, mm, ss))
+watch.rtc.set_localtime((yyyy, mm, dd, HH, MM, SS))
 wasp.run()
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ watch.rtc.set_localtime((yyyy, mm, dd, HH, MM, SS))
 wasp.run()
 ~~~
 
+Or just use:
+~~~
+./tools/wasptool --rtc
+~~~
+which can run these commands automatically.
+
 As mentioned above there are many drivers and features still to be
 developed, see the [TODO list](TODO.md) for current status.
 


### PR DESCRIPTION
As far as I can tell, `set_time` hasn't existed since this commit: https://github.com/daniel-thompson/wasp-os/commit/127df66335657cbd77539a509d507a4fcfb403b2

I haven't been able to track down when it disappeared, but it doesn't exist in the current RTC driver. The original implementation didn't allow for setting the date anyway it seems. This PR updates the readme to reference `set_localtime()` instead.

I couldn't get `set_time()` to work when working through the readme, but I'm new to wasp-os within the last couple of days. Feel free to just close this if I've understood something fundamental.