### PR TITLE
optimize touch controller driver for power saving and responsiveness

### DIFF
--- a/wasp/boards/pinetime/watch.py.in
+++ b/wasp/boards/pinetime/watch.py.in
@@ -67,7 +67,7 @@ battery = Battery(
 button = Pin('BUTTON', Pin.IN)
 i2c = I2C(1, scl='I2C_SCL', sda='I2C_SDA')
 accel = BMA421(i2c)
-touch = CST816S(i2c)
+touch = CST816S(i2c, Pin('TP_INT', Pin.IN), Pin('TP_RST', Pin.OUT, value=0))
 vibrator = Vibrator(Pin('MOTOR', Pin.OUT, value=0), active_low=True)
 
 # Release flash from deep power-down

--- a/wasp/boards/simulator/watch.py
+++ b/wasp/boards/simulator/watch.py
@@ -13,6 +13,7 @@ def print_exception(exc, file=sys.stdout):
 sys.print_exception = print_exception
 
 import draw565
+import array
 
 from machine import I2C
 from machine import Pin

--- a/wasp/drivers/cst816s.py
+++ b/wasp/drivers/cst816s.py
@@ -84,7 +84,6 @@ class CST816S:
         """
         self._reset()
         self.touch_en = True
-        self.event[0] = 0
 
     def sleep(self):
         """Put touch controller chip on sleep mode to save power.
@@ -94,3 +93,4 @@ class CST816S:
         dbuf = bytearray([0xA5, 0x03])
         self.i2c.writeto(21, dbuf)
         self.touch_en = False
+        self.event[0] = 0

--- a/wasp/drivers/cst816s.py
+++ b/wasp/drivers/cst816s.py
@@ -6,6 +6,8 @@
 """
 
 import array
+import time
+from machine import Pin
 
 class CST816S:
     """Hynitron CST816S I2C touch controller driver.
@@ -13,14 +15,44 @@ class CST816S:
     .. automethod:: __init__
     """
     
-    def __init__(self, bus):
+    def __init__(self, bus, _int, _rst):
         """Specify the bus used by the touch controller.
 
         :param machine.I2C bus: I2C bus for the CST816S.
         """
         self.i2c = bus
+        self.tp_int = _int  
+        self.tp_rst = _rst
         self.dbuf = bytearray(6)
         self.event = array.array('H', (0, 0, 0))
+        self.touch_en = True
+
+        self._reset()
+        self.tp_int.irq(trigger=Pin.IRQ_FALLING, handler=self.get_touch_data)
+
+    def _reset(self):
+        self.tp_rst.off()
+        time.sleep_ms(5)
+        self.tp_rst.on()
+        time.sleep_ms(50)
+
+    def get_touch_data(self, pin_obj):
+        """Receive a touch event by interrupt.
+
+        Check for a pending touch event and, if an event is pending,
+        prepare it ready to go in the event queue.
+        """
+        dbuf = self.dbuf
+        event = self.event
+
+        try:
+            self.i2c.readfrom_mem_into(21, 1, dbuf)
+        except OSError:
+            return None
+
+        event[0] = dbuf[0] # event
+        event[1] = ((dbuf[2] & 0xf) << 8) + dbuf[3] # x coord
+        event[2] = ((dbuf[4] & 0xf) << 8) + dbuf[5] # y coord
 
     def get_event(self):
         """Receive a touch event.
@@ -30,38 +62,35 @@ class CST816S:
 
         :return: An event record if an event is received, None otherwise.
         """
-        dbuf = self.dbuf
-        event = self.event
-
-        # TODO: check the interrupt pin
-
-        try:
-            self.i2c.readfrom_mem_into(21, 1, dbuf)
-        except OSError:
+        if self.event[0] == 0:
             return None
 
-        # Skip junk events
-        if dbuf[0] == 0:
+        if not self.touch_en:
             return None
 
-        x = ((dbuf[2] & 0xf) << 8) + dbuf[3]
-        y = ((dbuf[4] & 0xf) << 8) + dbuf[5]
-        swipe_start = dbuf[2] & 0x80
-        
-        # Skip identical events... when the I2C interface comes alive
-        # we can still get back stale events
-        if dbuf[0] == event[0] and x == event[1] and y == event[2] \
-                and not swipe_start:
-            return None
+        return self.event
 
-        # This is a good event, lets save it
-        event[0] = dbuf[0]
-        event[1] = x
-        event[2] = y
+    def reset_touch_data(self):
+        """Reset touch data.
 
-        # Do not forward swipe start events
-        if dbuf[2] & 0x80:
-            event[0] = 0
-            return None
+        Reset touch data, call this function after processed an event.
+        """
+        self.event[0] = 0
 
-        return event
+    def wake(self):
+        """Wake up touch controller chip.
+
+        Just reset the chip in order to wake it up
+        """
+        self._reset()
+        self.touch_en = True
+        self.event[0] = 0
+
+    def sleep(self):
+        """Put touch controller chip on sleep mode to save power.
+        """
+        self._reset()
+        # send 0x03 to register 0xA5 to put the controller on sleep mode
+        dbuf = bytearray([0xA5, 0x03])
+        self.i2c.writeto(21, dbuf)
+        self.touch_en = False

--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -232,6 +232,7 @@ class Manager():
             self.switch(self.quick_ring[0])
             self.app.sleep()
         watch.display.poweroff()
+        watch.touch.sleep()
         self._charging = watch.battery.charging()
         self.sleep_at = None
 
@@ -241,9 +242,7 @@ class Manager():
         watch.display.poweron()
         self.app.wake()
         watch.backlight.set(self._brightness)
-
-        # Discard any pending touch events
-        _ = watch.touch.get_event()
+        watch.touch.wake()
 
         self.keep_awake()
 
@@ -277,6 +276,7 @@ class Manager():
                 self.navigate(event[0])
         elif event[0] == 5 and self.event_mask & EventMask.TOUCH:
             self.app.touch(event)
+        watch.touch.reset_touch_data()
 
     def _tick(self):
         """Handle the system tick.


### PR DESCRIPTION
This PR include :

1. Utilized Interrupt Pin (P28) which connected to interrupt of touch controller so it tell the microcontroller new touch data is ready to check.

2. Put touch controller into sleep mode when watch go to sleep state so the touch controller doesn't drain the battery. This implemented by send 0x03 to register 0xA5 of touch controller. the reference for this could be read [here](https://wiki.pine64.org/index.php/PineTime#Registers)
