### PR TITLE
Update preprocess to use $(BOARD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ reloader: bootloader
 softdevice:
 	micropython/ports/nrf/drivers/bluetooth/download_ble_stack.sh
 
-micropython: wasp/boards/pinetime/watch.py
+micropython: wasp/boards/$(BOARD)/watch.py
 	$(MAKE) -C micropython/mpy-cross
 	$(RM) micropython/ports/nrf/build-$(BOARD)-s132/frozen_content.c
 	$(MAKE) -C micropython/ports/nrf \
@@ -43,9 +43,9 @@ micropython: wasp/boards/pinetime/watch.py
 		--application micropython/ports/nrf/build-$(BOARD)-s132/firmware.hex \
 		micropython.zip
 
-wasp/boards/pinetime/watch.py : wasp/boards/pinetime/watch.py.in
-	(cd wasp; ../tools/preprocess.py boards/pinetime/watch.py.in > \
-		                         boards/pinetime/watch.py)
+wasp/boards/$(BOARD)/watch.py : wasp/boards/$(BOARD)/watch.py.in
+	(cd wasp; ../tools/preprocess.py boards/$(BOARD)/watch.py.in > \
+		                         boards/$(BOARD)/watch.py)
 
 dfu:
 	python3 -m nordicsemi dfu serial --package micropython.zip --port /dev/ttyACM0


### PR DESCRIPTION
The preprocess to create watch.py was hard coded for PineTime so changed to $(BOARD)
This will be required for other watches like the P8