### PR TITLE
Fix background color of strings.

### DIFF
--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -291,21 +291,23 @@ class Draw565(object):
         display = self._display
         bgfg = self._bgfg
         font = self._font
+        bg = self._bgfg >> 16
 
         if width:
             (w, h) = _bounding_box(s, font)
             leftpad = (width - w) // 2
             rightpad = width - w - leftpad
-            self.fill(0, x, y, leftpad, h)
+            self.fill(bg, x, y, leftpad, h)
             x += leftpad
 
         for ch in s:
             glyph = font.get_ch(ch)
             _draw_glyph(display, glyph, x, y, bgfg)
+            self.fill(bg, x+glyph[2], y, 1, glyph[1])
             x += glyph[2] + 1
 
         if width:
-            self.fill(0, x, y, rightpad, h)
+            self.fill(bg, x, y, rightpad, h)
 
     def wrap(self, s, width):
         """Chunk a string so it can rendered within a specified width.


### PR DESCRIPTION
Before, the background color was only applied to the direct background of the characters, as seen in this picture. 
![Bildschirmfoto von 2020-07-31 13-51-20](https://user-images.githubusercontent.com/65309140/89035153-be26d000-d33a-11ea-99d9-bdbb86d04175.png)

The padding and the spacing between the characters was not affected. After these changes, it now looks as expected when using a custom background color:
![Bildschirmfoto von 2020-07-31 14-34-11](https://user-images.githubusercontent.com/65309140/89035356-1362e180-d33b-11ea-951b-21a945ac342d.png)

