### PR TITLE
Add GitHub Actions workflows (manually triggered) for building wasp-os

### DIFF
--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -19,12 +19,8 @@ jobs:
           libsdl2-2.0.0 python3-click python3-numpy python3-pexpect python3-pil python3-pip python3-serial
       - name: Install Python dependencies
         run: pip3 install --user pysdl2
-      - name: Download toolchain
-        run: curl -o gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D
       - name: Setup toolchain
-        run: tar xvzf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 &&
-          echo "export PATH=$PATH:$(eval pwd)/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc &&
-          source ~/.bashrc
+        run: sudo apt-get install gcc-arm-none-eabi
       - name: Checkout wasp-os
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -21,12 +21,10 @@ jobs:
         run: pip3 install --user pysdl2
       - name: Setup toolchain
         run: sudo apt-get install gcc-arm-none-eabi
-      - name: Sync submodules
-        run: git submodule sync --recursive && git submodule update
       - name: Checkout wasp-os
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - name: Sync submodules
+        run: git submodule sync --recursive && git submodule update
       - name: Build dependencies
         run: make submodules && make softdevice
       - name: Build firmware

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Setup toolchain
         run: sudo apt-get install gcc-arm-none-eabi
       - name: Checkout wasp-os
-        uses: actions/checkout@v2
-      - name: Sync submodules
-        run: git submodule sync --recursive && git submodule update
+        run: git clone https://github.com/MirkoCovizzi/wasp-os --recursive
       - name: Build dependencies
         run: make submodules && make softdevice
       - name: Build firmware

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -19,6 +19,11 @@ jobs:
           libsdl2-2.0.0 python3-click python3-numpy python3-pexpect python3-pil python3-pip python3-serial
       - name: Install Python dependencies
         run: pip3 install --user pysdl2
+      - name: Setup toolchain
+        run: curl -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D &&
+          tar xvzf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 &&
+          echo "export PATH=$PATH:$(eval pwd)/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc &&
+          source ~/.bashrc
       - name: Checkout wasp-os
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -19,9 +19,10 @@ jobs:
           libsdl2-2.0.0 python3-click python3-numpy python3-pexpect python3-pil python3-pip python3-serial
       - name: Install Python dependencies
         run: pip3 install --user pysdl2
+      - name: Download toolchain
+        run: curl -o gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D
       - name: Setup toolchain
-        run: curl -o gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D &&
-          tar xvzf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 &&
+        run: tar xvzf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 &&
           echo "export PATH=$PATH:$(eval pwd)/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc &&
           source ~/.bashrc
       - name: Checkout wasp-os

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Python dependencies
         run: pip3 install --user pysdl2
       - name: Setup toolchain
-        run: curl -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D &&
+        run: curl -o gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D &&
           tar xvzf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 &&
           echo "export PATH=$PATH:$(eval pwd)/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc &&
           source ~/.bashrc

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup toolchain
         run: sudo apt-get install gcc-arm-none-eabi
       - name: Checkout wasp-os
-        run: git clone https://github.com/MirkoCovizzi/wasp-os --recursive
+        uses: actions/checkout@v2
       - name: Build dependencies
         run: make submodules && make softdevice
       - name: Build firmware

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -21,6 +21,8 @@ jobs:
         run: pip3 install --user pysdl2
       - name: Setup toolchain
         run: sudo apt-get install gcc-arm-none-eabi
+      - name: Sync submodules
+        run: git submodule sync --recursive && git submodule update
       - name: Checkout wasp-os
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -8,11 +8,14 @@ on:
         required: true
         default: 'warning'
       tags:
-        description: 'Test scenario tags'
+        description: 'Build firmware'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        board: [pinetime, p8]
+    runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
         run: sudo apt-get update -y && sudo apt-get install git build-essential
@@ -20,20 +23,22 @@ jobs:
       - name: Install Python dependencies
         run: pip3 install --user pysdl2
       - name: Setup toolchain
-        run: sudo apt-get install gcc-arm-none-eabi
+        run: sudo apt-get update -y && sudo apt-get install gcc-arm-none-eabi
       - name: Checkout wasp-os
         uses: actions/checkout@v2
-      - name: Build dependencies
-        run: make submodules && make softdevice
+      - name: Setup submodules
+        run: make submodules
+      - name: Setup softdevice
+        run: make softdevice
       - name: Build firmware
-        run: make -j `nproc` BOARD=p8 all
+        run: make -j `nproc` BOARD=${{ matrix.board }} all
       - name: Persist bootloader
         uses: actions/upload-artifact@v2
         with:
-          name: bootloader-daflasher
+          name: ${{ matrix.board }}-bootloader-daflasher-artifact
           path: bootloader-daflasher.zip
       - name: Persist micropython
         uses: actions/upload-artifact@v2
         with:
-          name: micropython
+          name: ${{ matrix.board }}-micropython-artifact
           path: micropython.zip

--- a/.github/workflows/wasp-os.yml
+++ b/.github/workflows/wasp-os.yml
@@ -1,0 +1,39 @@
+name: wasp-os
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update -y && sudo apt-get install git build-essential
+          libsdl2-2.0.0 python3-click python3-numpy python3-pexpect python3-pil python3-pip python3-serial
+      - name: Install Python dependencies
+        run: pip3 install --user pysdl2
+      - name: Checkout wasp-os
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build dependencies
+        run: make submodules && make softdevice
+      - name: Build firmware
+        run: make -j `nproc` BOARD=p8 all
+      - name: Persist bootloader
+        uses: actions/upload-artifact@v2
+        with:
+          name: bootloader-daflasher
+          path: bootloader-daflasher.zip
+      - name: Persist micropython
+        uses: actions/upload-artifact@v2
+        with:
+          name: micropython
+          path: micropython.zip


### PR DESCRIPTION
An example of the artifacts generated can be found [here](https://github.com/MirkoCovizzi/wasp-os/actions/runs/191281313). These artifacts can be automatically downloaded for future publishing/releasing workflows ([by using the GitHub Action `actions/download-artifact@v2`](https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts)). They can also be manually downloaded and, after extraction, they can be flashed on the respective smartwatches.

In the future it is possible to add testing workflows and trigger them on PRs and other actions.