### PR TITLE
docs: install: Update Linux dependencies to fix compilation bug

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -83,7 +83,7 @@ following commands:
     sudo apt install \
       git build-essential libsdl2-2.0.0 \
       python3-click python3-numpy python3-pexpect \
-      python3-pil python3-pip python3-serial
+      python3-pil python3-pip python3-serial python
     pip3 install --user pysdl2
 
 You will also need a toolchain for the Arm Cortex-M4. wasp-os is developed and


### PR DESCRIPTION
This small PR serves the purpose of solving a compilation problem that happens on some Linux distributions (for example Ubuntu 20.04 LTS) that don't have `python` aka `Python 2.7` installed by default.

Without a functioning `python` system installed executable, the compilation process produces this log:

```
> make -j `nproc` BOARD=p8 all
rm -f bootloader/_build-p8_nrf52832//p8_nrf52832_bootloader-*-nosd.hex
(cd wasp; ../tools/preprocess.py ../wasp/boards/p8/watch.py.in > ../wasp/boards/p8/watch.py)
make -C bootloader/ BOARD=p8_nrf52832 all genhex
make[1]: Entering directory '/home/mirko/Documents/wasp-os/bootloader'
/usr/bin/env: ‘python’: No such file or directory
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error (underlined by me)
make: *** [Makefile:8: wasp/boards/p8/watch.py] Error 127
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Error (underlined by me)
make: *** Waiting for unfinished jobs....
CC main.c
CC boards.c
CC flash_nrf5x.c
CC dfu_ble_svc.c
CC dfu_init.c
CC nrfx_power.c
CC nrfx_nvmc.c
CC system_nrf52.c
CC bootloader.c
CC bootloader_settings.c
CC bootloader_util.c
CC dfu_transport_serial.c
CC dfu_transport_ble.c
CC dfu_single_bank.c
CC pstorage_raw.c
CC ble_dfu.c
CC ble_dis.c
CC app_timer.c
CC app_scheduler.c
CC app_error.c
CC app_util_platform.c
CC crc16.c
CC hci_mem_pool.c
CC hci_slip.c
CC hci_transport.c
CC nrf_assert.c
CC app_uart.c
CC nrf_drv_uart.c
CC nrf_drv_common.c
AS gcc_startup_nrf52.S
LD p8_nrf52832_bootloader-0.3.0-34-g89ba9a8-nosd.out

CR p8_nrf52832_bootloader-0.3.0-34-g89ba9a8-nosd.hex
   text	   data	    bss	    dec	    hex	filename
  23248	    152	  19970	  43370	   a96a	_build-p8_nrf52832/p8_nrf52832_bootloader-0.3.0-34-g89ba9a8-nosd.out

make[1]: Leaving directory '/home/mirko/Documents/wasp-os/bootloader'
python3 tools/hexmerge.py \
	bootloader/_build-p8_nrf52832/p8_nrf52832_bootloader-*-nosd.hex \
	bootloader/lib/softdevice/s132_nrf52_6.1.1/s132_nrf52_6.1.1_softdevice.hex \
	-o bootloader.hex
python3 tools/hex2c.py bootloader.hex > \
	reloader/src/boards/p8/bootloader.h
python3 -m nordicsemi dfu genpkg \
	--bootloader bootloader/_build-p8_nrf52832//p8_nrf52832_bootloader-*-nosd.hex \
	--softdevice bootloader/lib/softdevice/s132_nrf52_6.1.1/s132_nrf52_6.1.1_softdevice.hex \
	bootloader-daflasher.zip
Failed to import ecdsa, cannot do signing
Zip created at bootloader-daflasher.zip
```

This compilation ends successfully even though it has a silent error. As you can see, this generates only a `bootloader-daflasher.zip` (which is apparently not a normal behavior based on my research). A subsequent call of the same `make -j `nproc` BOARD=p8 all` would produce successfully also a `reloader.zip` and a `micropython.zip`, however all of these end up being unbootable because of the aforementioned silent error. After installation of `python`, instead, it is possible to successfully compile a bootable image.