### PR TITLE
wasptool: Change Python shebang to ensure compatibility

### DIFF
--- a/tools/wasptool
+++ b/tools/wasptool
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (c) 2020 Daniel Thompson


### PR DESCRIPTION
- Certain Unix-like systems (such as *BSD systems) do not use /usr/bin/python3 as the default Python path. This small change will ensure a higher degree of compatibility.