### PR TITLE
Remove attempt to wake flash at this level

### DIFF
--- a/wasp/boards/pinetime/watch.py.in
+++ b/wasp/boards/pinetime/watch.py.in
@@ -96,15 +96,9 @@ try:
                     _callback)
     vibrator = Vibrator(Pin('MOTOR', Pin.OUT, value=0), active_low=True)
 
-    # Release flash from deep power-down
-    boot_msg("Wake SPINOR")
-    nor_cs = Pin('NOR_CS', Pin.OUT, value=1)
-    nor_cs(0)
-    spi.write('\xAB')
-    nor_cs(1)
-
     # Mount the filesystem
     boot_msg("Init SPINOR")
+    nor_cs = Pin('NOR_CS', Pin.OUT, value=1)
     flash = FLASH(spi, (nor_cs,))
     try:
         boot_msg("Mount FS")


### PR DESCRIPTION
Wake from deep power down is now handled in the driver. Remove attempt to wake the chip from this file.

Signed-off-by: Jeffrey Bailey <wb.jeffrey@gmail.com>