### PR TITLE
Adjust pulse vibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ cscope.out
 docs/build
 attic/
 wasp/boards/*/watch.py
+
+# IDEs
+.vscode
+.idea

--- a/wasp/drivers/vibrator.py
+++ b/wasp/drivers/vibrator.py
@@ -26,7 +26,7 @@ class Vibrator(object):
         self.period = 16000
         self.active_low = active_low
 
-    def pulse(self, duty=25, ms=40):
+    def pulse(self, duty=10, ms=225):
         """Briefly pulse the motor.
 
         :param int duty: Duty cycle, in percent.


### PR DESCRIPTION
### Summary

While playing around with the notifications on the Colmi P8 I've noticed that I often miss messages as the default vibration pulse is rather quick and weak. Playing around with the vibration class I've found the default set to .225 seconds to be more of reliable prompt. 

This is a personal taste and feel free to close off and ignore but I thought it was worth raising for discussions if anyone else thinks it might be worth a bump.

Signed-off-by: Aidan Houlihan aidandhoulihan@gmail.com