### PR TITLE
Add wget to build dependencies

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,7 +19,7 @@ following commands:
 .. code-block:: sh
 
     sudo apt install \
-      git build-essential libsdl2-2.0.0 python3-click python3-numpy \
+      wget git build-essential libsdl2-2.0.0 python3-click python3-numpy \
       python3-pexpect python3-pil python3-pip python3-serial unzip
     pip3 install --user pysdl2
 


### PR DESCRIPTION
Wget needs to be installed to run `make softdevice`. Most distros have it installed by default, but it's better to have it in the list to be sure.