### PR TITLE
Fix Settings app showing Mid on launch while slider is at Low.

### DIFF
--- a/wasp/apps/settings.py
+++ b/wasp/apps/settings.py
@@ -19,6 +19,7 @@ class SettingsApp():
 
     def __init__(self):
         self._slider = wasp.widgets.Slider(3, 10, 90)
+        self._slider.value = wasp.system.brightness - 1
 
     def foreground(self):
         self._draw()


### PR DESCRIPTION
This fixes issue #108 

Signed-off-by: kozova1 <mug66kk@gmail.com>