### PR TITLE
drivers: draw565: Added line() drawing function.

### DIFF
--- a/wasp/apps/testapp.py
+++ b/wasp/apps/testapp.py
@@ -23,7 +23,7 @@ class TestApp():
     ICON = icons.app
 
     def __init__(self):
-        self.tests = ('Alarm', 'Button', 'Crash', 'Colours', 'Fill', 'Fill-H', 'Fill-V', 'Notifications', 'RLE', 'String', 'Touch', 'Wrap')
+        self.tests = ('Alarm', 'Button', 'Crash', 'Colours', 'Fill', 'Fill-H', 'Fill-V', 'Line', 'Notifications', 'RLE', 'String', 'Touch', 'Wrap')
         self.test = self.tests[0]
         self.scroll = wasp.widgets.ScrollIndicator()
 
@@ -101,6 +101,8 @@ class TestApp():
                     event[1], event[2]), 0, 108, width=240)
         elif self.test == 'Wrap':
             self._benchmark_wrap()
+        elif self.test == 'Line':
+            self._benchmark_line()
 
     def _alarm(self):
         wasp.system.wake()
@@ -164,6 +166,23 @@ class TestApp():
         draw.string("the lazy dog.", 12, 24+72)
         draw.string("0123456789", 12, 24+120)
         draw.string('!"£$%^&*()', 12, 24+144)
+        elapsed = t.time()
+        t.stop()
+        del t
+        draw.string('{}s'.format(elapsed / 1000000), 12, 24+192)
+
+    def _benchmark_line(self):
+        draw = wasp.watch.drawable
+        # instead of calculating by trig functions, use LUT
+        points = ((120, 170), (139, 166), (155, 155), (166, 139), (170, 120), (166, 101), (155, 85), (139, 74), (120, 70))
+
+
+        draw.fill(0, 120, 120, 50, 50)
+        self.scroll.draw()
+        t = machine.Timer(id=1, period=8000000)
+        t.start()
+        for x, y in points:
+            draw.line(120, 120, x, y, 0x1f)
         elapsed = t.time()
         t.stop()
         del t

--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -355,3 +355,52 @@ class Draw565(object):
             chunks.append(end)
 
         return chunks
+
+    def line(self, x0=0, y0=0, x1=0, y1=0, color=0xffff):
+        """Draw a line between points (x0;y0) and (x1;y1) with color.
+
+        Example:
+
+        .. code-block:: python
+
+            draw = wasp.watch.drawable
+            draw.line(0, 120, 240, 240, 0xf800)
+
+        :param x0: X coordinate of the start of the line, defaults to 0
+        :param x1: Y coordinate of the end of the line, defaults to 0
+        :param y0: Y coordinate of the start of the line, defaults to 0
+        :param y1: Y coordinate of the end of the line, defaults to 0
+        :param color: Color to draw line in, in RGB565 format, defaults to 0xffff
+        """
+
+        px = bytes(((color >> 8) & 0xFF, color & 0xFF))
+        write_data = self._display.write_data
+        set_window = self._display.set_window
+
+        dx =  abs(x1 - x0)
+        sx = 1 if x0 < x1 else -1
+        dy = -abs(y1 - y0)
+        sy = 1 if y0 < y1 else -1
+        err = dx + dy
+        if dx == 0 or dy == 0:
+            if x1 < x0 or y1 < y0:
+                x0, x1 = x1, x0
+                y0, y1 = y1, y0
+            w = 1 if dx == 0 else dx
+            h = 1 if dy == 0 else -dy
+            self.fill(color, x0, y0, w, h)
+            return
+        while True:
+            set_window(x0, y0, 1, 1)
+            write_data(px)
+            if x0 == x1 and y0 == y1:
+                break
+            e2 = 2 * err
+            if e2 >= dy:
+                err += dy
+                x0 += sx
+            if e2 <= dx:
+                err += dx;
+                y0 += sy;
+        
+


### PR DESCRIPTION
This is the API:
`drawable.line(x1, y1, x2, y2, color)`

~Note: we have to find a better way to draw single pixels,
currently it uses fill() calls which are very expensive.~

The function has optimizations for the case of vertical or horizontal lines.

Signed-off-by: Kozova1 <mug66kk@gmail.com>