### PR TITLE
Added labels to the dates in settings.py

### DIFF
--- a/wasp/apps/settings.py
+++ b/wasp/apps/settings.py
@@ -113,6 +113,8 @@ class SettingsApp():
             self._yy.draw()
             self._mm.draw()
             self._dd.draw()
+            draw.set_font(fonts.sans24)
+            draw.string('DD    MM    YY',0,180, width=240)
         self._scroll_indicator.draw()
         self._update()
         mute(False)


### PR DESCRIPTION
Hi, I'm new to the wasp-os project, and I just got my workflow up and running. I went into the settings app to set the time and date, but I was confused by the British ordering of the days and months! This pull request adds some text underneath the numbers to help out first time users. I've tested this commit on the simulator and on my PineTime watch. 

Signed-off-by: Isaiah Grace <isaiah@graces.com>