### PR TITLE
st7789: Fix incorrect variable name in ST7789_SPIs. __init__ docstring.

### DIFF
--- a/wasp/drivers/st7789.py
+++ b/wasp/drivers/st7789.py
@@ -202,7 +202,7 @@ class ST7789_SPI(ST7789):
         :param int height: Height of the display
         :param machine.SPI spi: SPI controller
         :param machine.Pin cs: Pin (or signal) to use as the chip select
-        :param machine.Pin cs: Pin (or signal) to use to switch between data
+        :param machine.Pin dc: Pin (or signal) to use to switch between data
                                and command mode.
         :param machine.Pin res: Pin (or signal) to, optionally, use to reset
                                 the display.


### PR DESCRIPTION
The data signal pin name is dc, not cs.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>