### PR TITLE
Initial Lift-To-Wake implementation

### DIFF
--- a/wasp/drivers/lift_to_wake.py
+++ b/wasp/drivers/lift_to_wake.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2020 Jannis Froese
+
+"""A pseudo-device to handle lift-to-wake
+~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+class LiftToWake(object):
+    """Lift-to-Wake handler
+
+    .. a lift-to-wake implementation that uses an existing accelerometer without dedicated lift-to-wake support
+
+    .. automethod:: __init__
+    """
+
+    def __init__(self, accelerometer, rtc):
+        """Create a lift-to-wake handler"""
+        self.accel = accelerometer
+        self.rtc = rtc
+        self._updateAt = rtc.get_uptime_ms()
+        self.wakeCount = 0
+
+    def update(self):
+        """update internal state, returns true if device was lifted"""
+        if self.rtc.get_uptime_ms() < self._updateAt:
+            return False
+        self._updateAt = self.rtc.get_uptime_ms() + 125
+
+        (x, y, z) = self.accel.acceleration
+        #print(y < 1 and y > -3 and x < -2 and z < -3 and z - x < -3 and z - x > -6, y < 1, y > -1, x < -2, z < -3, z-x < -3, z-x > -6, z-x, x, y, z)
+        if y < 1 and y > -3  and x < -2 and z < -3 and z - x < -3 and z - x > -6:
+            self.wakeCount += 1
+            return True
+        return False

--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -140,6 +140,7 @@ class Manager():
         else:
             self._nfylevels = [0, 40, 80]
         self._nfylev_ms = self._nfylevels[self._notifylevel - 1]
+        self._lift_to_wake_enabled = 'lift_to_wake' in dir(watch)
         self._button = PinHandler(watch.button)
         self._charging = True
         self._scheduled = False
@@ -204,6 +205,19 @@ class Manager():
     def notify_duration(self):
         """Cached copy of the current vibrator pulse duration in milliseconds"""
         return self._nfylev_ms
+
+    @property
+    def lift_to_wake_supported(self):
+        return 'lift_to_wake' in dir(watch)
+
+    @property
+    def lift_to_wake_enabled(self):
+        return self._lift_to_wake_enabled
+    
+    @lift_to_wake_enabled.setter
+    def lift_to_wake_enabled(self, value):
+        self._lift_to_wake_enabled = value and self.lift_to_wake_supported
+    
 
     def switch(self, app):
         """Switch to the requested application.
@@ -458,6 +472,8 @@ class Manager():
         else:
             if 1 == self._button.get_event() or \
                     self._charging != watch.battery.charging():
+                self.wake()
+            if self._lift_to_wake_enabled and watch.lift_to_wake.update():
                 self.wake()
 
     def run(self, no_except=True):


### PR DESCRIPTION
This implements #131 for devices with a compatible accelerometer (so currently only #149).

I have implemented it as a "driver", allowing any board to use it with the available accelerometer driver or replace it with a different implementation (for example because of hardware lift-to-wake support).

To test the code, merge it with #149, and in boards/p8b/watch.py.in add `from drivers.lift_to_wake import LiftToWake` around line 36 and `lift_to_wake = LiftToWake(accel, rtc)` around line 99. Then add `'drivers/lift_to_wake.py',` around line 22 of boards/p8b/manifest.py, recomile, upload and you are done.

Usually "lift-to-wake" requires you to lift your arm and hold a position with the watch tilted by about 15 degrees. Getting a reliable lift detection that also works while walking seems hard, but it turns out that just detecting the end state is actually enough. You just have to hold you arm vertically, then tilt it slightly towards you. This works even with your arm resting on a surface.

Signed-off-by: Jannis Froese <jannisfroese@mailbox.org>