### PR TITLE
drivers: draw565: Added bounding_box() to check physical size of string

### DIFF
--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -330,6 +330,14 @@ class Draw565(object):
         if width:
             self.fill(bg, x, y, rightpad, h)
 
+    def bounding_box(self, s):
+        """Return the bounding box of a string.
+
+        :param s: A string
+        :returns: Tuple of (width, height)
+        """
+        return _bounding_box(s, self._font)
+
     def wrap(self, s, width):
         """Chunk a string so it can rendered within a specified width.
 


### PR DESCRIPTION
Example:

```py
width, height = wasp.watch.drawable.bounding_box("Hello")
```

Warning: This was only tested in the simulator, but it hopefully should not break anything on the watch.

Signed-off-by: kozova1 <mug66kk@gmail.com>