### PR TITLE
Add ability and setting to wake screen when a notification is received

### DIFF
--- a/wasp/apps/settings.py
+++ b/wasp/apps/settings.py
@@ -37,7 +37,9 @@ class SettingsApp():
         self._dd = wasp.widgets.Spinner(20, 60, 1, 31, 1)
         self._mm = wasp.widgets.Spinner(90, 60, 1, 12, 1)
         self._yy = wasp.widgets.Spinner(160, 60, 20, 60, 2)
-        self._settings = ['Brightness', 'Notification Level', 'Time', 'Date']
+        self._von = wasp.widgets.Checkbox(3, 40, 'Vibrate')
+        self._won = wasp.widgets.Checkbox(3, 80, 'Wake Screen')
+        self._settings = ['Brightness', 'Notification Level', 'Time', 'Date', 'Notifications']
         self._sett_index = 0
         self._current_setting = self._settings[0]
 
@@ -68,6 +70,12 @@ class SettingsApp():
                 now[1] = self._mm.value
                 now[2] = self._dd.value
                 wasp.watch.rtc.set_localtime(now)
+        elif self._current_setting == 'Notifications':
+            if self._von.touch(event):
+                wasp.system.vibe_on_notif = self._von.state
+            elif self._won.touch(event):
+                wasp.system.wake_on_notif = self._won.state
+            print(wasp.system.vibe_on_notif, wasp.system.wake_on_notif)
         self._update()
 
     def swipe(self, event):
@@ -115,6 +123,11 @@ class SettingsApp():
             self._dd.draw()
             draw.set_font(fonts.sans24)
             draw.string('DD    MM    YY',0,180, width=240)
+        elif self._current_setting == 'Notifications':
+            self._von.state = wasp.system.vibe_on_notif
+            self._won.state = wasp.system.wake_on_notif
+            self._von.draw()
+            self._won.draw()
         self._scroll_indicator.draw()
         self._update()
         mute(False)

--- a/wasp/gadgetbridge.py
+++ b/wasp/gadgetbridge.py
@@ -49,7 +49,11 @@ def GB(cmd):
             id = cmd['id']
             del cmd['id']
             wasp.system.notify(id, cmd)
-            wasp.watch.vibrator.pulse(ms=wasp.system.notify_duration)
+            if wasp.system.vibe_on_notif:
+                wasp.watch.vibrator.pulse(ms=wasp.system.notify_duration)
+            if wasp.system.wake_on_notif:
+                wasp.system.switch(wasp.NotificationApp())
+                wasp.system.wake()
         elif task == 'notify-':
             wasp.system.unnotify(cmd['id'])
         elif task == 'musicstate':

--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -144,6 +144,8 @@ class Manager():
         self._charging = True
         self._scheduled = False
         self._scheduling = False
+        self._vibe_on_notif = True
+        self._wake_on_notif = False
 
         # TODO: Eventually these should move to main.py
         for app, qr in ( (ClockApp, True),
@@ -204,6 +206,24 @@ class Manager():
     def notify_duration(self):
         """Cached copy of the current vibrator pulse duration in milliseconds"""
         return self._nfylev_ms
+
+    @property
+    def vibe_on_notif(self):
+        """Vibrate when a notification is received bool"""
+        return self._vibe_on_notif
+
+    @vibe_on_notif.setter
+    def vibe_on_notif(self, value):
+        self._vibe_on_notif = value
+
+    @property
+    def wake_on_notif(self):
+        """Wake the screen when a notification is received bool"""
+        return self._wake_on_notif
+
+    @wake_on_notif.setter
+    def wake_on_notif(self, value):
+        self._wake_on_notif = value
 
     def switch(self, app):
         """Switch to the requested application.


### PR DESCRIPTION
- Added the ability to wake the watch screen when a notification is received
- Added settings to the settings app to allow vibration and screen wake to be enabled or disabled by the user from the watch itself

I loaded this onto my own PineTime devkit hardware I use daily and it has been working for the last 24 hours without an issue. I left the default setting as "vibrate only" since that is what it always was.

This is my first _ever_ pull request and I do not know python. I did my best to follow existing conventions. If I did anything wrong, please let me know and I'll be happy to fix it. I've been using open source for over a decade and I am excited to finally be able to give back!

Signed-off-by: zack+github@nullh.net