### PR TITLE
Change SWIPE_LEFTRIGHT to SWIPE_UPDOWN in the music app.

### DIFF
--- a/wasp/apps/musicplayer.py
+++ b/wasp/apps/musicplayer.py
@@ -110,7 +110,7 @@ class MusicPlayerApp(object):
         wasp.watch.drawable.fill()
         self.draw()
         wasp.system.request_tick(1000)
-        wasp.system.request_event(wasp.EventMask.SWIPE_LEFTRIGHT |
+        wasp.system.request_event(wasp.EventMask.SWIPE_UPDOWN |
                                   wasp.EventMask.TOUCH)
 
     def background(self):


### PR DESCRIPTION
The music player volume control uses up and down events, but in the foreground function the app requests left and right events.

Signed-off-by: Tait Berlette <54515877+taitberlette@users.noreply.github.com>