### PR TITLE
draw565: Avoid over-long lines when handling space

### DIFF
--- a/wasp/draw565.py
+++ b/wasp/draw565.py
@@ -370,15 +370,19 @@ class Draw565(object):
                 if i >= len(s):
                     break
                 ch = s[i]
-                if ch == '\n':
-                    end = i+1
-                    break
-                if ch == ' ':
-                    end = i+1
                 (_, h, w) = font.get_ch(ch)
                 l += w + 1
                 if l > width:
                     break
+
+                # Break the line immediately if requested
+                if ch == '\n':
+                    end = i+1
+                    break
+
+                # Remember the right-most place we can cleanly break the line
+                if ch == ' ':
+                    end = i+1
             if end <= start:
                 end = i
             chunks.append(end)


### PR DESCRIPTION
Currently, if the line wrapper attempts to break a line on a space and
that space character is outside the bounding box, then we generate an
over-long line.

Fix this by handling line break generation *after* we have checked the
length of the current line.

Fixes: #193
Signed-off-by: Daniel Thompson <daniel@redfelineninja.org.uk>