### PR TITLE
MemoryError exception now shows custom message instead of CrashApp.

### DIFF
--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -497,6 +497,8 @@ class Manager():
                 self._tick()
             except KeyboardInterrupt:
                 raise
+            except MemoryError:
+                self.switch(PagerApp("Your watch is low on memory.\n\nYou may want to reboot."))
             except Exception as e:
                 # Only print the exception if the watch provides a way to do so!
                 if 'print_exception' in dir(watch):
@@ -513,6 +515,8 @@ class Manager():
         self._scheduled = False
         try:
             self._tick()
+        except MemoryError:
+            self.switch(PagerApp("Your watch is low on memory.\n\nYou may want to reboot."))
         except Exception as e:
             # Only print the exception if the watch provides a way to do so!
             if 'print_exception' in dir(watch):


### PR DESCRIPTION
The MemoryError exception happens quite a bit for me, so I decided to make it a bit neater. Instead of showing the entire error message, the MemoryError shows the problem and suggests how to fix it.

Signed-off-by: Tait Berlette <54515877+taitberlette@users.noreply.github.com>