### PR TITLE
Fix escape sequences in wasptool

### DIFF
--- a/tools/wasptool
+++ b/tools/wasptool
@@ -223,7 +223,7 @@ def handle_rtc(c):
 
 def check_rtc(c):
     c.sendline('print(watch.rtc.get_localtime())')
-    c.expect('\(([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+)\)')
+    c.expect(r'\(([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+)\)')
     t = time.localtime()
 
     watch_hms = (int(c.match[4]), int(c.match[5]), int(c.match[6]))
@@ -385,7 +385,7 @@ if __name__ == '__main__':
         console.logfile = io.StringIO()
 
     try:
-        console.expect('Connect.*\(([0-9A-F:]*)\)')
+        console.expect(r'Connect.*\(([0-9A-F:]*)\)')
     except pexpect.exceptions.TIMEOUT:
         print('ERROR: Cannot find suitable wasp-os device')
         if not args.verbose:


### PR DESCRIPTION
I typically run with `PYTHONWARNINGS=default` (for other development work), and this PR helps avoid two recurring warnings when using `wasptool`:

```
/home/andreas/pack/wasp-os/./tools/wasptool:226: DeprecationWarning: invalid escape sequence \(
  c.expect('\(([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+)\)')
/home/andreas/pack/wasp-os/./tools/wasptool:388: DeprecationWarning: invalid escape sequence \(
  console.expect('Connect.*\(([0-9A-F:]*)\)')
```

Also, thanks for all you do on waspos!