### PR TITLE
apps: Fixed weather app with GadgetBridge.

### DIFF
--- a/wasp/apps/settings.py
+++ b/wasp/apps/settings.py
@@ -37,7 +37,9 @@ class SettingsApp():
         self._dd = wasp.widgets.Spinner(20, 60, 1, 31, 1)
         self._mm = wasp.widgets.Spinner(90, 60, 1, 12, 1)
         self._yy = wasp.widgets.Spinner(160, 60, 20, 60, 2)
-        self._settings = ['Brightness', 'Notification Level', 'Time', 'Date']
+        self._units = ['Metric', 'Imperial']
+        self._units_toggle = wasp.widgets.Button(32, 90, 176, 48, "Change")
+        self._settings = ['Brightness', 'Notification Level', 'Time', 'Date', 'Units']
         self._sett_index = 0
         self._current_setting = self._settings[0]
 
@@ -68,6 +70,9 @@ class SettingsApp():
                 now[1] = self._mm.value
                 now[2] = self._dd.value
                 wasp.watch.rtc.set_localtime(now)
+        elif self._current_setting == 'Units':
+            if self._units_toggle.touch(event):
+                wasp.system.units = self._units[(self._units.index(wasp.system.units) + 1) % len(self._units)]
         self._update()
 
     def swipe(self, event):
@@ -115,6 +120,8 @@ class SettingsApp():
             self._dd.draw()
             draw.set_font(fonts.sans24)
             draw.string('DD    MM    YY',0,180, width=240)
+        elif self._current_setting == 'Units':
+            self._units_toggle.draw()
         self._scroll_indicator.draw()
         self._update()
         mute(False)
@@ -140,3 +147,5 @@ class SettingsApp():
                 say = "Silent"
             self._nfy_slider.update()
             draw.string(say, 0, 150, width=240)
+        elif self._current_setting == 'Units':
+            draw.string(wasp.system.units, 0, 150, width=240)

--- a/wasp/apps/weather.py
+++ b/wasp/apps/weather.py
@@ -50,10 +50,10 @@ class WeatherApp(object):
     ICON = icon
     
     def __init__(self):
-        self._temp = ''
-        self._hum = ''
+        self._temp = -1
+        self._hum = 0
         self._txt = ''
-        self._wind = ''
+        self._wind = 0
         self._loc = ''
         self._temp_changed = True
         self._hum_changed = True
@@ -136,16 +136,32 @@ class WeatherApp(object):
 
     def _draw(self):
         """Redraw the updated zones."""
-        if self._temp_changed:
-            self._draw_label(self._temp, 54, 36)
-        if self._hum_changed:
-            self._draw_label("Humidity: "+self._hum, 160)
-        if self._txt_changed:
-            self._draw_label(self._txt, 12)
-        if self._wind_changed:
-            self._draw_label("Wind: "+self._wind, 120)
-        if self._loc_changed:
-            self._draw_label(self._loc, 200)
+        draw = wasp.watch.drawable
+        if self._temp != -1:
+            units = wasp.system.units
+            temp = self._temp - 273.15
+            wind = self._wind
+            wind_units = "km/h"
+            if units == "Imperial":
+                temp = (temp * 1.8) + 32
+                wind = wind / 1.609
+                wind_units = "mph"
+            temp = round(temp)
+            wind = round(wind)
+            if self._temp_changed:
+                self._draw_label(str(temp), 54, 36)
+            if self._hum_changed:
+                self._draw_label("Humidity: {}%".format(self._hum), 160)
+            if self._txt_changed:
+                self._draw_label(self._txt, 12)
+            if self._wind_changed:
+                self._draw_label("Wind: {}{}".format(wind, wind_units), 120)
+            if self._loc_changed:
+                self._draw_label(self._loc, 200)
+        else:
+            if self._temp_changed:
+                draw.fill()
+                self._draw_label("No weather data.", 120)
 
     def _draw_label(self, label, pos, size = 24):
         """Redraw label info"""

--- a/wasp/boards/simulator/main.py
+++ b/wasp/boards/simulator/main.py
@@ -14,10 +14,10 @@ wasp.system.set_music_info({
     })
 
 wasp.system.set_weather_info({
-    'temp': '22',
-    'hum': '100%',
+    'temp': 295,
+    'hum': 100,
     'txt': 'Cloudy',
-    'wind': '25km/h',
+    'wind': 25,
     'loc': 'Toronto'
 })
 

--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -113,6 +113,7 @@ class Manager():
         self.musicstate = {}
         self.musicinfo = {}
         self.weatherinfo = {}
+        self.units = "Metric"
 
         self._theme = (
                 b'\x7b\xef'     # ble


### PR DESCRIPTION
When I created the weather app I didn't have GadgetBridge installed, so I tried to follow the protocol on the [espurino website](https://www.espruino.com/Gadgetbridge), but it wasn't very helpful and I made some mistakes. This commit should fix these mistakes to stop the weather app from crashing, and so it displays the correct values. I have also added a new settings option called "Units", where apps can see what units the user would prefer (metric/imperial).

Signed-off-by: Tait Berlette <54515877+taitberlette@users.noreply.github.com>