### PR TITLE
Make all notifications show in pager instead of one at a time 

### DIFF
--- a/wasp/apps/pager.py
+++ b/wasp/apps/pager.py
@@ -88,10 +88,15 @@ class NotificationApp(PagerApp):
 
     def foreground(self):
         notes = wasp.system.notifications
-        note = notes.pop(next(iter(notes)))
-        title = note['title'] if 'title' in note else 'Untitled'
-        body = note['body'] if 'body' in note else ''
-        self._msg = '{}\n\n{}'.format(title, body)
+        self._msg = ""
+        i = 1
+        l = len(notes)
+        for note in notes:
+            title = notes[note]['title'] if 'title' in notes[note] else 'Untitled'
+            body = notes[note]['body'] if 'body' in notes[note] else ''
+            self._msg = self._msg + '({}/{}){}:\n{}\n\n'.format(i, l, title, body)
+            i += 1
+
 
         wasp.system.request_event(wasp.EventMask.TOUCH)
         super().foreground()

--- a/wasp/apps/pager.py
+++ b/wasp/apps/pager.py
@@ -96,8 +96,6 @@ class NotificationApp(PagerApp):
             body = notes[note]['body'] if 'body' in notes[note] else ''
             self._msg = self._msg + '({}/{}){}:\n{}\n\n'.format(i, l, title, body)
             i += 1
-
-
         wasp.system.request_event(wasp.EventMask.TOUCH)
         super().foreground()
 


### PR DESCRIPTION
The way notifications are currently shown makes it really hard to get an overview, because only one notification is shown at a time and it gets removed after seeing it.

This patch makes a single string of all notifications and shows them in the pager.
Viewing the notifications does not remove them, but the ability to remove all notification is still available.  

![NotificationsApp](https://user-images.githubusercontent.com/55393142/140171826-c0601c65-8066-487c-bf1f-a1a77c07805e.png)
