### PR TITLE
Add *.mpy to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.steps
 *.zip
 .*.swp
+*.mpy
 __pycache__
 cscope.out
 docs/build


### PR DESCRIPTION
.mpy files are micropython bytecode and should be ignored.
Now that user-defined apps are implemented, it's likely that .mpy files
will be present in apps/