### PR TITLE
Add make and CI rules for building apps .mpy files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,12 @@ jobs:
           make -j `nproc` VERSION=${{ github.sha }} dist
           mv ../wasp-os-${{ github.sha }}.tar.gz .
 
+    - name: Build extra apps
+      id:   apps
+      run:  |
+          export PATH=$PATH:${{ runner.temp }}/arm-none-eabi/bin
+          make -j `nproc` apps
+
     - name: Upload full binary distribution
       id:   upload-binaries
       uses: actions/upload-artifact@v2
@@ -87,3 +93,10 @@ jobs:
       with:
           name: k9-${{ github.sha }}
           path: build-k9
+
+    - name: Upload extra apps binaries
+      id:   upload-apps
+      uses: actions/upload-artifact@v2
+      with:
+          name: apps-${{ github.sha }}
+          path: apps/*.mpy

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,10 @@ wasp/boards/$(BOARD_SAFE)/watch.py : wasp/boards/$(BOARD_SAFE)/watch.py.in
 	(cd wasp; ../tools/preprocess.py boards/$(BOARD)/watch.py.in > boards/$(BOARD)/watch.py) \
 		|| ($(RM) wasp/boards/$(BOARD)/watch.py; false)
 
-micropython: build-$(BOARD_SAFE) wasp/boards/$(BOARD_SAFE)/watch.py
+micropython/mpy-cross/mpy-cross:
 	$(MAKE) -C micropython/mpy-cross
+
+micropython: build-$(BOARD_SAFE) wasp/boards/$(BOARD_SAFE)/watch.py micropython/mpy-cross/mpy-cross
 	$(RM) micropython/ports/nrf/build-$(BOARD)-s132/frozen_content.c
 	$(MAKE) -C micropython/ports/nrf \
 		BOARD=$(BOARD) SD=s132 \
@@ -88,6 +90,13 @@ debug:
 		-ex "monitor swdp_scan" \
 		-ex "attach 1" \
 		-ex "load"
+
+apps/%.mpy: apps/%.py micropython/mpy-cross/mpy-cross
+	./micropython/mpy-cross/mpy-cross -mno-unicode -march=armv7m $<
+APPS_PY=$(wildcard apps/*.py)
+APPS_MPY=$(APPS_PY:%.py=%.mpy)
+.PHONY: apps
+apps: $(APPS_MPY)
 
 docs:
 	$(RM) -rf docs/build/html/*


### PR DESCRIPTION
So that users can just download the .mpy files instead of having to build the whole toolchain