### PR TITLE
Correct HRM gain value

### DIFF
--- a/wasp/drivers/hrs3300.py
+++ b/wasp/drivers/hrs3300.py
@@ -43,7 +43,8 @@ class HRS3300:
 
         # 64x gain
         #w(_HGAIN, 0x10)
-        w(_HGAIN, 0x03)
+        # 8x gain
+        w(_HGAIN, 0xc)
 
     def read_reg(self, addr):
         return self._i2c.readfrom_mem(_I2CADDR, addr, 1)[0]


### PR DESCRIPTION
The current value of 0x03 sets the gain to 1x, this change should correctly set it to 8x.

Signed-off-by: Kieran Cawthray <kieranc@gmail.com>