### PR TITLE
fix: system.switch(self) when in foreground cancel motor vibrations

### DIFF
--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -245,6 +245,9 @@ class Manager():
     def switch(self, app):
         """Switch to the requested application.
         """
+        if self.app is app:
+            return
+
         if self.app:
             if 'background' in dir(self.app):
                 try:


### PR DESCRIPTION
Hi,

It's an issue I had several times in the passed. Right now I'm forking the timerapp and notice that calling wasp.system.switch(self) while the app is not in the background actually resets ticks and stops the watch from vibrating.

I think it's not an expected behavior so I'm proposing this PR.
