### PR TITLE
docs: explicit --binary help

### DIFF
--- a/tools/wasptool
+++ b/tools/wasptool
@@ -370,7 +370,7 @@ if __name__ == '__main__':
     parser.add_argument('--bootloader', action='store_true',
             help="Reboot into the bootloader mode for OTA update")
     parser.add_argument('--binary', action='store_true',
-            help="Enable non-ASCII mode for suitable commands (such as upload)")
+            help="Enable non-ASCII mode for upload command")
     parser.add_argument('--console', action='store_true',
             help='Launch a REPL session')
     parser.add_argument('--check-rtc', action='store_true',


### PR DESCRIPTION
Explicitely tell the user in the help that --binary only applies to --upload. I think this is needed because I thought it could apply to --eval --exec --push and --pull.


Btw: I think it would be good to change the order of the arguments to something more logical instead of alphabetical. If you agree I'll do that after this PR gets merged.