### PR TITLE
docs: explain that Manager.run is not usually run

### DIFF
--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -498,7 +498,9 @@ class Manager():
 
         This allows all watch management activities to handle in the
         normal execution context meaning any exceptions and other problems
-        can be observed interactively via the console.
+        can be observed interactively via the console. This is used by the
+        simulator or for debugging is not normally called. The watch instead
+        calls self.schedule() directly at startup from main.py.
         """
         if self._scheduling:
             print('Watch already running in the background')


### PR DESCRIPTION
I was scratching my head for a while to understand how run was called and found the name misleading.

I think it would also be worth it to be a bit more explicit in explaining how schedule() is called for those like me who are familiar with python but not micropython or electronics.


Signed-off-by: thiswillbeyourgithub <github@32mail.33mail.com>
