### PR TITLE
Implement hardware-based raise-to-wake gesture with software fallback

### DIFF
--- a/wasp/apps/settings.py
+++ b/wasp/apps/settings.py
@@ -39,7 +39,8 @@ class SettingsApp():
         self._yy = wasp.widgets.Spinner(160, 60, 20, 60, 2)
         self._units = ['Metric', 'Imperial']
         self._units_toggle = wasp.widgets.Button(32, 90, 176, 48, "Change")
-        self._settings = ['Brightness', 'Notification Level', 'Time', 'Date', 'Units']
+        self._raise_to_wake_toggle = wasp.widgets.Button(32, 90, 176, 48, "On/Off")
+        self._settings = ['Brightness', 'Notification Level', 'Time', 'Date', 'Units', 'Raise To Wake']
         self._sett_index = 0
         self._current_setting = self._settings[0]
 
@@ -73,6 +74,9 @@ class SettingsApp():
         elif self._current_setting == 'Units':
             if self._units_toggle.touch(event):
                 wasp.system.units = self._units[(self._units.index(wasp.system.units) + 1) % len(self._units)]
+        elif self._current_setting == "Raise To Wake":
+            if self._raise_to_wake_toggle.touch(event):
+                wasp.system.raise_wake = not wasp.system.raise_wake
         self._update()
 
     def swipe(self, event):
@@ -122,6 +126,8 @@ class SettingsApp():
             draw.string('DD    MM    YY',0,180, width=240)
         elif self._current_setting == 'Units':
             self._units_toggle.draw()
+        elif self._current_setting == 'Raise To Wake':
+            self._raise_to_wake_toggle.draw()
         self._scroll_indicator.draw()
         self._update()
         mute(False)
@@ -149,3 +155,9 @@ class SettingsApp():
             draw.string(say, 0, 150, width=240)
         elif self._current_setting == 'Units':
             draw.string(wasp.system.units, 0, 150, width=240)
+        elif self._current_setting == 'Raise To Wake':
+            if wasp.system.raise_wake:
+                say = "On"
+            else:
+                say = "Off"
+            draw.string(say, 0, 150, width=240)

--- a/wasp/boards/k9/manifest.py
+++ b/wasp/boards/k9/manifest.py
@@ -22,6 +22,7 @@ freeze('../..', manifest_240x240.manifest +
         'gadgetbridge.py',
         'ppg.py',
         'shell.py',
+        'motion.py',
         'wasp.py',
     ),
     opt=3

--- a/wasp/boards/p8/manifest.py
+++ b/wasp/boards/p8/manifest.py
@@ -22,6 +22,7 @@ freeze('../..', manifest_240x240.manifest +
         'gadgetbridge.py',
         'ppg.py',
         'shell.py',
+        'motion.py',
         'wasp.py',
     ),
     opt=3

--- a/wasp/boards/pinetime/manifest.py
+++ b/wasp/boards/pinetime/manifest.py
@@ -22,6 +22,7 @@ freeze('../..', manifest_240x240.manifest +
         'gadgetbridge.py',
         'ppg.py',
         'shell.py',
+        'motion.py',
         'wasp.py',
     ),
     opt=3

--- a/wasp/boards/pinetime/watch.py.in
+++ b/wasp/boards/pinetime/watch.py.in
@@ -90,7 +90,7 @@ try:
             Signal(Pin('CHARGING', Pin.IN), invert=True),
             Signal(Pin('USB_PWR', Pin.IN), invert=True))
     i2c = I2C(1, scl='I2C_SCL', sda='I2C_SDA')
-    accel = BMA421(i2c)
+    accel = BMA421(i2c, Pin('ACCEL_INT', Pin.IN))
     hrs = HRS3300(i2c)
     touch = CST816S(i2c,
                     Pin('TP_INT', Pin.IN), Pin('TP_RST', Pin.OUT, value=0),

--- a/wasp/motion.py
+++ b/wasp/motion.py
@@ -1,0 +1,85 @@
+import watch
+import sys
+
+from micropython import const
+
+_WRIST_TILT_Y_SWITCH_THRESHOLD = const(-768)
+_WRIST_TILT_SPEED_MODIFIER = const(8)
+_WRIST_TILT_X_THRESHOLD = const(512)
+_WRIST_TILT_Y_THRESHOLD = const(0)
+_WRIST_TILT_REQUIRED_SPEED = const(256)
+
+_POLL_INTERVAL_MS = const(100)
+
+class AccelGestureEvent():
+    """Enumerated ids for accelerometer-based gesture events
+    """
+    NONE = const(0)
+    WRIST_TILT = const(1)
+
+class MotionDetector():
+    """Handles motion detection using either hardware-backed events
+    or algorithms implemented in software
+    """
+
+    def __init__(self):
+        self._last_x = sys.maxsize
+        self._last_y = sys.maxsize
+        self._last_z = sys.maxsize
+        self._poll_expiry = 0
+        self._event = AccelGestureEvent.NONE
+        watch.accel.reset()
+
+    def get_gesture_event(self):
+        return self._event
+
+    def reset_gesture_event(self):
+        self._event = AccelGestureEvent.NONE
+
+    def update(self):
+        now = watch.rtc.get_uptime_ms()
+        if now < self._poll_expiry:
+            return
+
+        self._poll_expiry = now + _POLL_INTERVAL_MS
+
+        # Prioritize hardware-based gestures
+        # TODO: Allow drivers to specify *which* gestures they can detect
+        if watch.accel.hardware_gesture_available:
+            self._event = watch.accel.get_gesture_event()
+            watch.accel.reset_gesture_event()
+            return
+
+        (x, y, z) = watch.accel.accel_xyz()
+
+        if self._last_x == sys.maxsize:
+            self._last_x = x
+            self._last_y = y
+            self._last_z = z
+            return
+
+        if self._detect_wrist_tilt(x, y, z):
+            self._event = AccelGestureEvent.WRIST_TILT
+
+        self._last_x = x
+        self._last_y = y
+        self._last_z = z
+
+    def _detect_wrist_tilt(self, x, y, z):
+        # To make our code match InfiniTime, flip the coordinate system first
+        (x, y, z) = (-x, -y, -z)
+        (last_y, last_z) = (-self._last_y, -self._last_z)
+
+        delta_y = y - last_y
+        delta_z = z - last_z
+
+        if abs(x) > _WRIST_TILT_X_THRESHOLD or y > _WRIST_TILT_Y_THRESHOLD:
+            return False
+
+        if y < _WRIST_TILT_Y_SWITCH_THRESHOLD:
+            return delta_z > _WRIST_TILT_REQUIRED_SPEED
+
+        if z > 0:
+            return delta_y > (_WRIST_TILT_REQUIRED_SPEED + (y - delta_y / 2) / _WRIST_TILT_SPEED_MODIFIER)
+
+        return delta_y < (-_WRIST_TILT_REQUIRED_SPEED - (y - delta_y / 2) / _WRIST_TILT_SPEED_MODIFIER)

--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -21,6 +21,7 @@ import steplogger
 import sys
 import watch
 import widgets
+import motion
 
 from apps.launcher import LauncherApp
 from apps.pager import PagerApp, CrashApp, NotificationApp
@@ -114,6 +115,8 @@ class Manager():
         self.musicinfo = {}
         self.weatherinfo = {}
         self.units = "Metric"
+        self.raise_wake = False
+        self.motion = motion.MotionDetector()
 
         self._theme = (
                 b'\x7b\xef'     # ble
@@ -493,6 +496,15 @@ class Manager():
                     self._charging != watch.battery.charging():
                 self.wake()
 
+        if self.raise_wake:
+            self.motion.update()
+            event = self.motion.get_gesture_event()
+
+            if event == motion.AccelGestureEvent.WRIST_TILT:
+                self.wake()
+
+            self.motion.reset_gesture_event()
+    
     def run(self, no_except=True):
         """Run the system manager synchronously.
 


### PR DESCRIPTION
With the BMA425 accelerometer shipped with newer PineTime units, it is
possible to configure gesture detection on the hardware and send
interrupts to the nRF chips when detected. The supported gestures
include wrist-twist, double-tap and single-tap.

This commit implements optional raise-to-wake support based on such a
hardware feature. However, for compatibility with earlier units, which
has a BMA421 sensor that does not support gesture detection, we also
introduce a software-based detection algorithm for fallback. This
algorithm is based on the InfiniTime equivalent
<https://github.com/InfiniTimeOrg/InfiniTime/pull/826>.

Due to the way the accelerometer is mounted inside the PineTime, axes
remapping is needed for the hardware to detect the gestures correctly.
This was already implemented in the bma42x driver, and only needs to be
exposed to the Python side via bma42x-upy, which will have a
corresponding pull request for that.

Note that the hardware will never remap the raw data readout -- the
remapping information provided to the hardware will only be used in the
hardware-based algorithms, such as step counting and gesture detection.

Previously in #275, software-based axes remapping was already
introduced, however the mapping was inconsistent with what the hardware
expects. The hardware expects a left-handed coordinate system flipped
around the origin: when worn on the left wrist, the directions down, left,
and towards the user should be positive. On the PineTime, this translates
to all axes being flipped *and* the x and y axes swapped.

The software mapping is now corrected to agree with what the hardware
expects. This also means that apps making use of the accelerometer (for
now, just the Level app) will need to be changed, but that is beyond the
scope of this commit.

Co-authored-by: Ashley Eastwood <aeastw.git@fastmail.co.uk>
Co-authored-by: Finlay Davidson <finlay.davidson@coderclass.nl>