### PR TITLE
new: import step counter later

### DIFF
--- a/wasp/wasp.py
+++ b/wasp/wasp.py
@@ -17,14 +17,12 @@
 import gc
 import machine
 import micropython
-import steplogger
 import sys
 import watch
 import widgets
 
 from apps.launcher import LauncherApp
 from apps.pager import PagerApp, CrashApp, NotificationApp
-from apps.steps import StepCounterApp
 
 class EventType():
     """Enumerated interface actions.
@@ -200,8 +198,13 @@ class Manager():
         # "Special case" for watches that have working step counters!
         # More usefully it allows other apps to detect the presence/absence
         # of a working step counter by looking at wasp.system.steps .
-        if isinstance(app, StepCounterApp):
-            self.steps = steplogger.StepLogger(self)
+        if app.NAME == "Steps":
+            try:
+                import steplogger
+                self.steps = steplogger.StepLogger(self)
+            except ImportError:
+                self.switch(PagerApp("Could not import steplogger, maybe you "
+                                     "disabled it in the manifest?"))
 
         if watch_face:
             self.quick_ring[0] = app


### PR DESCRIPTION
When disabling the stepcounter in the manifest, the watch refuses to boot without issuing error. I think this fix would make it more clear and easier to save on RAM.

Signed-off-by: thiswillbeyourgithub <github@32mail.33mail.com>
