### PR TITLE
add comment warning to ignore IDE asking to remove unused imports

### DIFF
--- a/wasp/drivers/battery.py
+++ b/wasp/drivers/battery.py
@@ -5,6 +5,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 import micropython
+# don't remove Pin import even though your IDE tells you it's unused, otherwise
+# micropython can't load your battery level.
 from machine import Pin, ADC
 
 class Battery(object):


### PR DESCRIPTION
Hi,

Very simple PR to add a comment for newcomers to ignore the PEP8 warning to remove "import Pin" as it stops the battery level from updating as it was one of the first thing I did...
