### PR TITLE
Faster heart rate display

### DIFF
--- a/wasp/apps/heart.py
+++ b/wasp/apps/heart.py
@@ -43,6 +43,7 @@ class HeartApp():
     def __init__(self):
         self._debug = False
         self._hrdata = None
+        self._last_value = wasp.watch.rtc.time()
 
     def foreground(self):
         """Activate the application."""
@@ -72,9 +73,11 @@ class HeartApp():
 
         spl = self._hrdata.preprocess(wasp.watch.hrs.read_hrs())
 
-        if len(self._hrdata.data) >= 240:
+        bpm = self._hrdata.get_heart_rate()
+        if bpm and (wasp.watch.rtc.time() - self._last_value) > 1.5:
+            self._last_value = wasp.watch.rtc.time()
             draw.set_color(wasp.system.theme('bright'))
-            draw.string('{} bpm'.format(self._hrdata.get_heart_rate()),
+            draw.string('{} bpm'.format(bpm),
                         0, 6, width=240)
 
         # Graph is orange by default...

--- a/wasp/ppg.py
+++ b/wasp/ppg.py
@@ -163,13 +163,14 @@ class PPG():
         return (60 * 24 * 4) // t3
 
     def get_heart_rate(self):
-        if len(self.data) < 200:
+        if len(self.data) < 24:  # don't estimate under 1 sec of recording
             return None
 
         hr = self._get_heart_rate()
 
-        # Clear out the accumulated data
-        self.data = array.array('b')
+        if hr is not None and len(self.data) > 240:
+            # Clear out passed accumulated data more than 10s ago
+            self.data = array.array('b', self.data[-240:])
 
         # Dump the debug data
         if self.debug:


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <github@32mail.33mail.com>
Hi,

After chatting with @drtonyr I ended up spending some time in `ppg.py` and figured that instead of waiting 10s to display the heart rate you could just wait 1s, then display the value and every new second recompute a more accurate value.

Hopefully this will get my friends to restart using the watch I offered them :)
