### PR TITLE
docs: add a short note about the p8 plus variant

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -258,6 +258,9 @@ display with touch screen, a step counter and a heart rate sensor.
     boot wasp-os successfully but the step counter application will
     be disabled and cannot function.
 
+    The newer "Colmi P8 Plus" is based on the GR5515 instead of NRF52832
+    and is currently unsupported.
+
 DaFlasher for Android can be used to install both the
 :ref:`wasp-bootloader<Bootloader DaFlasher>` and the
 :ref:`main OS image<Main OS DaFlasher>`. No tools or disassembly is


### PR DESCRIPTION
I recently made the mistake of purchasing a "P8 Plus" instead of a P8. I hope this comment will help others not make a similar mistake.

It sound like this has happened before too, albeit under slightly different circumstances https://github.com/daniel-thompson/wasp-os/issues/259